### PR TITLE
Passing the same params to the run function, as Sailor passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ can always be found in be used within the context of execution. The most up-to-d
 of the component. Below is a sample for the reference:
 
  - `console`: - more on [Node.js console](https://nodejs.org/dist/latest-v5.x/docs/api/console.html),
- - `process`: - Current Node.js process,
- - `require`: - Module require,
+ - `process`: - current Node.js process,
+ - `require`: - module require,
  - `setTimeout`: - more on [setTimeout](https://nodejs.org/dist/latest-v5.x/docs/api/timers.html),
  - `clearTimeout`: - more on [clearTimeout](https://nodejs.org/dist/latest-v5.x/docs/api/timers.html),
  - `setInterval`: - more on setInterval,
  - `clearInterval`: - more on clearInterval,
- - `msg`: - Incoming message containing the payload from the previous step,
+ - `msg`: - incoming message containing the payload from the previous step,
+ - `cfg`: - step's configuration. At the moment contains only one property: `code` (the code, being executed),
+ - `snapshot` - step's snapshot, 
  - `exports`: {},
- - `messages`: - Utility for convenient message creation,
+ - `messages`: - utility for convenient message creation,
  - `request`: - Http Client (wrapped in `co` - [this library](https://www.npmjs.com/package/co-request)),
  - `wait`: - wait,
  - `emitter`: user to emit messages and errors
@@ -42,7 +44,7 @@ of the component. Below is a sample for the reference:
 Use code is very simple, just do following:
 
 ```JavaScript
-async function run(msg) {
+async function run(msg, cfg, snapshot) {
   console.log('Incoming message is %s', JSON.stringify(msg));
   const body = { result : 'Hello world!' };
   // You can emit as many data messages as required
@@ -62,9 +64,9 @@ of your function, it will be automatically emitted as data.
 an incoming message with code, just use following sample:
 
 ```JavaScript
-async function run(msg) => {
-  addition : "You can use code",
-  keys : Object.keys(msg)   
+async function run(msg, cfg, snapshot) => {
+  addition: "You can use code",
+  keys: Object.keys(msg)   
 }
 ```
 
@@ -73,7 +75,7 @@ async function run(msg) => {
 It's very simple to code a small REST API call out of the Code component, see following example:
 
 ```JavaScript
-async function run(msg) {
+async function run(msg, cfg, snapshot) {
   const res = await request.get({
     uri: 'https://api.elastic.io/v1/users',
     auth: {
@@ -92,5 +94,4 @@ async function run(msg) {
 
 ## Known issues and limitations
 
- - Snapshots are not supported
  - Credentials are not supported

--- a/actions/code.js
+++ b/actions/code.js
@@ -16,7 +16,7 @@ function wait(timeout) {
 }
 
 // eslint-disable-next-line consistent-return,func-names
-exports.process = async function (msg, conf) {
+exports.process = async function (msg, conf, snapshot) {
   const ctx = vm.createContext({
     _,
     console,
@@ -42,10 +42,11 @@ exports.process = async function (msg, conf) {
     let result;
     if (ctx.run.constructor.name === 'GeneratorFunction') {
       this.logger.info('Run variable is a generator');
-      result = co(ctx.run);
+      const fn = co.wrap(ctx.run);
+      result = fn.apply(this, [msg, conf, snapshot]);
     } else {
       this.logger.info('Run variable is a function, calling it');
-      result = ctx.run.apply(this, [msg]);
+      result = ctx.run.apply(this, [msg, conf, snapshot]);
     }
     if (typeof result === 'object' && typeof result.then === 'function') {
       this.logger.info('Returned value is a promise, will evaluate it');

--- a/actions/code.js
+++ b/actions/code.js
@@ -8,10 +8,10 @@ const request = require('co-request');
 function wait(timeout) {
   return new Promise((ok) => {
     setTimeout(() => {
-      this.logger.info('Done wait');
+      this.logger.debug('Done wait');
       ok();
     }, timeout);
-    this.logger.info('Start wait sec=%s', timeout);
+    this.logger.debug('Start wait sec=%s', timeout);
   });
 }
 
@@ -33,27 +33,27 @@ exports.process = async function (msg, conf, snapshot) {
     wait: wait.bind(this),
     emitter: this,
   });
-  this.logger.info('Running the code %s', conf.code);
+  this.logger.debug('Running the code %s', conf.code);
   vm.runInContext(conf.code, ctx, {
     displayErrors: true,
   });
-  this.logger.info("No result, let's check the run object if it was created?");
+  this.logger.debug("No result, let's check the run object if it was created?");
   if (ctx.run && typeof ctx.run.apply === 'function') {
     let result;
     if (ctx.run.constructor.name === 'GeneratorFunction') {
-      this.logger.info('Run variable is a generator');
+      this.logger.debug('Run variable is a generator');
       const fn = co.wrap(ctx.run);
       result = fn.apply(this, [msg, conf, snapshot]);
     } else {
-      this.logger.info('Run variable is a function, calling it');
+      this.logger.debug('Run variable is a function, calling it');
       result = ctx.run.apply(this, [msg, conf, snapshot]);
     }
     if (typeof result === 'object' && typeof result.then === 'function') {
-      this.logger.info('Returned value is a promise, will evaluate it');
+      this.logger.debug('Returned value is a promise, will evaluate it');
       let returnResult;
       try {
         returnResult = await result;
-        this.logger.info('Promise resolved');
+        this.logger.debug('Promise resolved');
         if (returnResult) {
           return messages.newMessageWithBody(returnResult);
         }
@@ -64,7 +64,7 @@ exports.process = async function (msg, conf, snapshot) {
       }
     }
   } else {
-    this.logger.info("Run function was not found, it's over now");
+    this.logger.debug("Run function was not found, it's over now");
     this.emit('end');
   }
 };

--- a/component.json
+++ b/component.json
@@ -8,7 +8,7 @@
             "viewClass": "CodeFieldView",
             "label": "Code",
             "required": true,
-            "default": "// Please note only Node.js code is supported here\nasync function run(msg) {\n\tthis.logger.info('Incoming message is %s', JSON.stringify(msg));\n\tconst body = { result : 'Hello world!' };\n\t// You can emit as many data messages as required\n\tawait this.emit('data', { body });\n\tthis.logger.info('Execution finished');\n}"
+            "default": "// Please note only Node.js code is supported here\nasync function run(msg, cfg, snapshot) {\n\tthis.logger.info('Incoming message is %s', JSON.stringify(msg));\n\tconst body = { result : 'Hello world!' };\n\t// You can emit as many data messages as required\n\tawait this.emit('data', { body });\n\tthis.logger.info('Execution finished');\n}"
         }
     },
     "actions": {


### PR DESCRIPTION
Before this change the `run` function received only `msg` argument. Now it receives `cfg` and `snapshot` as well.

`cfg` is not particularly useful, anyway. It just contains 1 property: `code`.

The reason is to make it as close as possible to the real process function.
With this change this component now will be able to work with snapshots.